### PR TITLE
1.0.4

### DIFF
--- a/Checks.lua
+++ b/Checks.lua
@@ -148,7 +148,7 @@ function Checks:GetCellContents(field, row, referenceRow, index)
       text = "...",
       tooltip = function()
         GameTooltip:SetText("No Response", 1, 1, 1);
-        GameTooltip:AddLine("Does this player have the verifier WeakAura installed?")
+        GameTooltip:AddLine("This player doesn't have the verifier installed OR they were in combat at the time of the check.")
       end
     }
   end

--- a/Interface.lua
+++ b/Interface.lua
@@ -167,7 +167,7 @@ function UI:CreateTableFrame(config)
       local isStickyRow = false
 
       if not rowFrame then
-        rowFrame = CreateFrame("Button", "$parentRow" .. rowIndex, tableFrame, "SecureActionButtonTemplate")
+        rowFrame = CreateFrame("Button", "$parentRow" .. rowIndex, tableFrame)
         rowFrame.columns = {}
         tableFrame.rows[rowIndex] = rowFrame
       end
@@ -242,7 +242,7 @@ function UI:CreateTableFrame(config)
         local columnTextAlign = columnConfig and columnConfig.align or "LEFT"
 
         if not columnFrame then
-          columnFrame = CreateFrame("Button", "$parentCol" .. columnIndex, rowFrame, "SecureActionButtonTemplate")
+          columnFrame = CreateFrame("Button", "$parentCol" .. columnIndex, rowFrame)
           columnFrame.text = columnFrame:CreateFontString("$parentText", "OVERLAY")
           columnFrame.text:SetFontObject("GameFontHighlightSmall")
           columnFrame.text:SetWordWrap(false)
@@ -268,7 +268,7 @@ function UI:CreateTableFrame(config)
               columnFrame.editBoxSave:Hide()
             end
           end)
-          columnFrame.editBoxSave = CreateFrame("Button", nil, columnFrame.editBox, "SecureActionButtonTemplate")
+          columnFrame.editBoxSave = CreateFrame("Button", nil, columnFrame.editBox)
           columnFrame.editBoxSave:SetPoint("RIGHT", columnFrame.editBox, "RIGHT", -30)
           columnFrame.editBoxSave:SetWidth(20)
           columnFrame.editBoxSave:SetHeight(20)

--- a/Main.lua
+++ b/Main.lua
@@ -542,7 +542,7 @@ function Main:GetMainColumns(unfiltered)
         GameTooltip:SetOwner(cellFrame, "ANCHOR_RIGHT")
         GameTooltip:SetText(weakAuraCheck.displayName, 1, 1, 1);
         GameTooltip:AddLine(weakAuraCheck.auraName, nil, nil, nil, true)
-        GameTooltip:AddLine(weakAuraCheck.wagoUrl, nil, nil, nil, true)
+        -- GameTooltip:AddLine(weakAuraCheck.wagoUrl, nil, nil, nil, true)
         GameTooltip:Show()
       end,
       onLeave = function()

--- a/Main.lua
+++ b/Main.lua
@@ -271,7 +271,7 @@ function Main:Render()
     end
 
     do -- WeakAuras Settings Button
-      self.window.titlebar.WeakAurasSettings = CreateFrame("Button", "$parentWeakAurasSettings", self.window.titlebar, "SecureActionButtonTemplate")
+      self.window.titlebar.WeakAurasSettings = CreateFrame("Button", "$parentWeakAurasSettings", self.window.titlebar)
       self.window.titlebar.WeakAurasSettings:SetPoint("RIGHT", self.window.titlebar.ColumnsButton, "LEFT", 0, 0)
       self.window.titlebar.WeakAurasSettings:SetSize(Constants.TITLEBAR_HEIGHT, Constants.TITLEBAR_HEIGHT)
       self.window.titlebar.WeakAurasSettings:SetScript("OnEnter", function()

--- a/Main.lua
+++ b/Main.lua
@@ -23,6 +23,7 @@ function Main:ToggleWindow()
     Settings.window:Hide()
     Settings.open = false
   else
+    if Data.cache.inCombat then return end
     self:RefreshTable()
     self.window:Show()
   end

--- a/Settings.lua
+++ b/Settings.lua
@@ -22,6 +22,7 @@ function Settings:ToggleWindow()
   if self.window:IsVisible() then
     self.window:Hide()
   else
+    if Data.cache.inCombat then return end
     self.window:Show()
   end
   self.weakAuras = Utils:TableCopy(Data.db.global.settings.weakAurasToTrack)
@@ -150,8 +151,7 @@ function Settings:Render()
   end
 
   -- Quick hotfix to avoid excessive rendering
-  if (not self.window:IsVisible() and not self.open) then
-    self.window:Hide()
+  if not self.window:IsVisible() then
     return
   end
 
@@ -222,9 +222,6 @@ function Settings:Render()
   self.window:SetHeight(windowHeight)
   self.window:SetClampRectInsets(self.window:GetWidth() / 2, self.window:GetWidth() / -2, 0, self.window:GetHeight() / 2)
   self.window:SetScale(Data.db.global.main.windowScale / 100)
-  if Data.cache.inCombat and Data.db.global.Settings.hideInCombat then
-    self.window:Hide()
-  end
 end
 
 function Settings:GetColumns()


### PR DESCRIPTION
* Hide reference to unused WeakAura wago URL field.
* Indicate that the verifier WA doesn't load in combat.
* Fix Lua error when trying to close the addon in combat.
* Attempt to fix an issue where the settings window could randomly pop up in combat.